### PR TITLE
Move timezone conversion to browser

### DIFF
--- a/main.go
+++ b/main.go
@@ -866,14 +866,8 @@ func processEvent(raw map[string]interface{}) Event {
 		timestamp = event.CreatedAt
 	}
 
-	// Parse timestamp and convert to local time
-	if t, err := time.Parse(time.RFC3339, timestamp); err == nil {
-		// Convert UTC to local timezone
-		localTime := t.Local()
-		event.FormattedTime = localTime.Format("2006-01-02 15:04:05")
-	} else {
-		event.FormattedTime = timestamp
-	}
+	// Keep timestamp in RFC3339 format for browser-side timezone conversion
+	event.FormattedTime = timestamp
 
 	// Extract body
 	if body, ok := raw["body"].(map[string]interface{}); ok {

--- a/templates/index.html
+++ b/templates/index.html
@@ -494,6 +494,27 @@
         // HELPER FUNCTIONS
         // ========================================
 
+        /**
+         * Format timestamp to local timezone
+         * Converts RFC3339/ISO timestamp to browser's local time
+         */
+        function formatTimestamp(timestamp) {
+            if (!timestamp) return 'N/A';
+            try {
+                const date = new Date(timestamp);
+                return date.toLocaleString('de-DE', {
+                    year: 'numeric',
+                    month: '2-digit',
+                    day: '2-digit',
+                    hour: '2-digit',
+                    minute: '2-digit',
+                    second: '2-digit'
+                });
+            } catch (e) {
+                return timestamp;
+            }
+        }
+
         function categorizeEvent(event) {
             // Use the category from backend if available
             if (event.codeCategory === 'fault') return 'fault';
@@ -649,7 +670,7 @@
                 return `
                     <div class="event-item" onclick="toggleEvent(${index})">
                         <div class="event-header">
-                            <div class="event-time">${event.formatted_time}</div>
+                            <div class="event-time">${formatTimestamp(event.eventTimestamp || event.createdAt)}</div>
                             <div class="event-type">
                                 ${event.errorCode ? `<strong>${event.errorCode}</strong>` : event.eventType}
                                 ${statusIndicator}


### PR DESCRIPTION
Server now sends RFC3339 timestamps without conversion. Browser converts timestamps to user's local timezone for display. This ensures consistent timezone display across all UI components.

fixes #4