### PR TITLE
Add ARM32 builds for Raspberry Pi support

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,6 +30,10 @@ builds:
     goarch:
       - amd64
       - arm64
+      - arm
+    goarm:
+      - "6"
+      - "7"
     tags:
       - nokeyring
     ldflags:


### PR DESCRIPTION
- Added ARMv6 and ARMv7 builds for container variant
- Supports all Raspberry Pi models (Zero, 1, 2, 3, 4, 5)
- All builds use nokeyring tag for headless environments

Fixes #10