### PR TITLE
Re-enable rate limiting (fix for merged PR #127)

### DIFF
--- a/viessmann_api.go
+++ b/viessmann_api.go
@@ -96,7 +96,7 @@ func setAPICallsCount() {
 
 // NewRequest wraps method http.NewRequest to track API calls
 func NewRequest(method, url string, body io.Reader) (*http.Request, error) {
-    req, err := http.NewRequest(method, url, body)
+	req, err := http.NewRequest(method, url, body)
 	if err == nil {
 		trackAPICall()
 		setAPICallsCount()


### PR DESCRIPTION
PR #127 fixed the API counting bug but disabled rate limiting.
Now that counting works correctly, the limits should be re-enabled to protect against hitting Viessmann API limits (120/10min, 1450/24hr).