### PR TITLE
Automatisches Anlegen des DB-Verzeichnisses bei Erstinstallation

### DIFF
--- a/db.go
+++ b/db.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -32,6 +34,12 @@ func InitEventDatabase(dbPath string) error {
 	// Close existing connection if any (only if reinitializing with different path)
 	if eventDB != nil {
 		eventDB.Close()
+	}
+
+	// Ensure the database directory exists
+	dbDir := filepath.Dir(dbPath)
+	if err := os.MkdirAll(dbDir, 0755); err != nil {
+		return fmt.Errorf("failed to create database directory: %v", err)
 	}
 
 	var err error


### PR DESCRIPTION
Behebt #130

Die SQLite-Datenbank wird jetzt automatisch bei der Erstinstallation angelegt, indem das übergeordnete Verzeichnis (z.B. `/config`) bei Bedarf mit `os.MkdirAll()` erstellt wird.

## Änderungen
- Import von `os` und `path/filepath` hinzugefügt
- Vor `sql.Open()` wird nun sichergestellt, dass das DB-Verzeichnis existiert
- Keine manuelle Erstellung der Datenbank mehr nötig