### PR TITLE
Add improvements from Issue #132

### DIFF
--- a/static/js/dashboard-render-heating.js
+++ b/static/js/dashboard-render-heating.js
@@ -154,8 +154,17 @@
                     </div>
                 `;
             }
-            // Gemeinsame Vorlauftemperatur
-            if (kf.supplyTemp) {
+
+            // Gemeinsame Vorlauftemperatur (only show when NO hot water buffer)
+            // Get hasHotWaterBuffer setting
+            const deviceKeyForSupplyTemp = `${deviceInfo.installationId}_${deviceInfo.deviceId}`;
+            const deviceSettingForSupplyTemp = window.deviceSettingsCache && window.deviceSettingsCache[deviceKeyForSupplyTemp];
+            let hasHotWaterBufferForSupplyTemp = false; // default
+            if (deviceSettingForSupplyTemp && deviceSettingForSupplyTemp.hasHotWaterBuffer !== null && deviceSettingForSupplyTemp.hasHotWaterBuffer !== undefined) {
+                hasHotWaterBufferForSupplyTemp = deviceSettingForSupplyTemp.hasHotWaterBuffer;
+            }
+
+            if (!hasHotWaterBufferForSupplyTemp && kf.supplyTemp) {
                 const formatted = formatValue(kf.supplyTemp);
                 const [value, ...unitParts] = formatted.split(' ');
                 const unit = unitParts.join(' ');


### PR DESCRIPTION
Improvements by @rudi-60 for better temperature chart and dashboard display.

## Changes

**Temperature Chart:**
- ✅ Intelligent field pre-selection based on `hasHotWaterBuffer` setting
  - With buffer → shows `secondary_supply_temp` (ODU)  
  - Without buffer → shows `primary_supply_temp` (IDU)
- ✅ Improved labels consistent with temperature_scheduler.go
  - `secondary_return_temp`: 'Lufteintrittstemperatur' (clearer than 'Sekundär-Rücklauf')
  - `primary_supply_temp`: 'Vorlauftemperatur (IDU)'
  - `secondary_supply_temp`: 'Sekundär-Vorlauf (ODU)'
- ✅ Better auto-range for Y-axis: 0.8×min, 1.1×max (more space for readability)

**Dashboard Heating:**
- ✅ Conditional display of 'Gemeinsame Vorlauftemperatur' (only when no buffer)

## Credits

Based on files uploaded by @rudi-60 in issue #132.

## Related

Addresses #132