### PR TITLE
Fix deltaT calculation without volumetric flow

### DIFF
--- a/temperature_scheduler.go
+++ b/temperature_scheduler.go
@@ -700,7 +700,7 @@ func calculateDerivedValues(snapshot *TemperatureSnapshot) {
 		// Calculate deltaT for each heating circuit individually
 		// NOTE: All circuits share the same return sensor, so these represent
 		// the temperature spread from each circuit's supply to the shared return
-		if snapshot.ReturnTemp != nil {
+		if snapshot.ReturnTemp != nil && snapshot.VolumetricFlow != nil && *snapshot.VolumetricFlow > 0 {
 			if snapshot.HeatingCircuit0SupplyTemp != nil {
 				deltaT0 := *snapshot.HeatingCircuit0SupplyTemp - *snapshot.ReturnTemp
 				snapshot.HeatingCircuit0DeltaT = &deltaT0


### PR DESCRIPTION
## Summary
Behebt die Berechnung der Temperaturspreizung (deltaT) für Heizkreise, wenn kein Volumenstrom vorhanden ist.

## Problem
Ohne Volumenstrom steht das Wasser im System still. Die gemessene Temperaturdifferenz zwischen Vorlauf und Rücklauf repräsentiert dann keine tatsächliche Wärmeabgabe, sondern nur die Temperaturverteilung im stehenden Wasser und führt zu irreführenden Werten.

## Änderung
Die deltaT-Berechnung für Heizkreise wird nur noch durchgeführt, wenn:
- `ReturnTemp` vorhanden ist
- `VolumetricFlow` vorhanden ist  
- `VolumetricFlow > 0` (tatsächlich Wasser fließt)

Dies ist konsistent mit der bereits bestehenden Logik für die Berechnung der thermischen Leistung.

## Test plan
- Prüfen, dass deltaT-Werte nur berechnet werden, wenn Volumenstrom vorhanden ist
- Prüfen, dass keine deltaT-Werte angezeigt werden, wenn die Anlage stillsteht

Fixes #176