### PR TITLE
Fix deltaT calculation for systems with hot water buffer

### DIFF
--- a/temperature_scheduler.go
+++ b/temperature_scheduler.go
@@ -687,11 +687,11 @@ func calculateDerivedValues(snapshot *TemperatureSnapshot) {
 	if snapshot.ThermalPower == nil && snapshot.VolumetricFlow != nil && supplyTemp != nil && returnTemp != nil {
 		deltaT := *supplyTemp - *returnTemp
 
-		// Fallback für 250-A und ähnliche Anlagen: Wenn Spreizung negativ wäre,
-		// verwende BoilerTemp statt supplyTemp. Bei manchen Anlagentypen liefert
+		// Fallback für 250-A und ähnliche Anlagen: Bei manchen Anlagentypen liefert
 		// die API die "gemeinsame Vorlauftemperatur" statt der höchsten Temperatur.
+		// Verwende BoilerTemp wenn diese höher ist als supplyTemp.
 		if snapshot.BoilerTemp != nil {
-			if deltaT < 0 || *snapshot.BoilerTemp > *supplyTemp {
+			if *snapshot.BoilerTemp > *supplyTemp {
 				supplyTemp = snapshot.BoilerTemp
 				deltaT = *supplyTemp - *returnTemp
 			}


### PR DESCRIPTION
## Summary
Fixes two issues in the temperature snapshot calculation:
- Corrects deltaT calculation for heating circuit 0 on systems with hot water buffer
- Prevents unrealistic thermal power values when volumetric flow is zero

## Details

### Issue 1: DeltaT calculation for buffer systems
**Problem:** For systems with hot water buffer (`hasHotWaterBuffer=true`), the `HeatingCircuit0DeltaT` was incorrectly calculated from `HeatingCircuit0SupplyTemp - ReturnTemp` instead of using the already calculated deltaT from the secondary circuit.

**Solution:** 
- Systems **with** buffer now use the deltaT calculated from secondary circuit (`HPSecondaryCircuitSupplyTemp - ReturnTemp`)
- Systems **without** buffer continue to use the heating circuit 0 supply temperature for calculation
- This ensures consistency with the thermal power calculation logic (lines 664-684)

### Issue 2: Thermal power without volumetric flow
**Problem:** Thermal power was calculated even when volumetric flow was zero, resulting in physically incorrect values.

**Solution:** Added volumetric flow check to the thermal power calculation condition:
- Changed from: `if deltaT > 0`
- Changed to: `if deltaT > 0 && *snapshot.VolumetricFlow > 0`

## Test plan
- [ ] Verify deltaT values for systems with hot water buffer are now consistent with secondary circuit temperatures
- [ ] Verify thermal power is not calculated when volumetric flow is zero
- [ ] Verify systems without buffer continue to work correctly

Fixes #179