### PR TITLE
WiFi-Stärke: -20 dBm Offset nur für Vitocal-Geräte

### DIFF
--- a/static/js/dashboard-render-heating.js
+++ b/static/js/dashboard-render-heating.js
@@ -2758,13 +2758,15 @@
             if (!kf.deviceSerial && !kf.deviceType && !kf.deviceVariant && !kf.scop && !kf.compressorStats) return '';
 
             let info = '';
+            let devVariant = '';
 
             // Basic device info
             if (kf.deviceVariant) {
+                devVariant = kf.deviceVariant.value;
                 info += `
                     <div class="status-item">
                         <span class="status-label">Modell</span>
-                        <span class="status-value">${kf.deviceVariant.value}</span>
+                        <span class="status-value">${devVariant}</span>
                     </div>
                 `;
             }
@@ -2788,13 +2790,20 @@
             }
 
             if (kf.deviceWiFi) {
-                const wifiStrength = kf.deviceWiFi.value.strength.value - 20.0;
-                info += `
-                    <div class="status-item">
-                        <span class="status-label">WiFi Pegel</span>
-                        <span class="status-value" style="font-family: monospace;">${wifiStrength} dBm</span>
-                    </div>
-                `;
+                let wifiStrength = kf.deviceWiFi.value.strength.value;
+                // Only apply -20 dBm offset for Vitocal devices
+                if (devVariant && devVariant.toLowerCase().includes("vitocal")) {
+                    wifiStrength = wifiStrength - 20.0;
+                }
+                // Filter out invalid values (< -115 dBm is unrealistic for WiFi)
+                if (wifiStrength > -115) {
+                    info += `
+                        <div class="status-item">
+                            <span class="status-label">WiFi Pegel</span>
+                            <span class="status-value" style="font-family: monospace;">${wifiStrength} dBm</span>
+                        </div>
+                    `;
+                }
             }
 
             // JAZ / COP / SCOP / SPF values (Coefficient of Performance)


### PR DESCRIPTION
## Änderung

Der -20 dBm Offset wird jetzt nur noch bei Vitocal-Geräten angewendet.

Bei Vitodens-Geräten wird der WiFi-Pegel nun direkt ohne Offset angezeigt, wie in der ViCare App.

## Technische Details

- Prüfung erfolgt case-insensitive über `devVariant.toLowerCase().includes("vitocal")`
- Ungültige Werte (< -115 dBm) werden gefiltert
- Kommentare im Code dokumentieren die Logik

## Hintergrund

Siehe Diskussion in #194

## Test

- Vitocal: API-Wert -56 dBm → Anzeige -76 dBm ✓
- Vitodens: API-Wert -62 dBm → Anzeige -62 dBm ✓