### PR TITLE
Feature: Zirkulationspumpe pro Heizkreis anzeigen

### DIFF
--- a/static/js/dashboard-render-engine.js
+++ b/static/js/dashboard-render-engine.js
@@ -485,6 +485,12 @@
                 fan0: find(['heating.primaryCircuit.fans.0.current']),
                 fan1: find(['heating.primaryCircuit.fans.1.current']),
 
+                // Heating circuits - circulation pumps
+                circuitPump0: findNested('heating.circuits.0.circulation.pump', 'status'),
+                circuitPump1: findNested('heating.circuits.1.circulation.pump', 'status'),
+                circuitPump2: findNested('heating.circuits.2.circulation.pump', 'status'),
+                circuitPump3: findNested('heating.circuits.3.circulation.pump', 'status'),
+
                 // Efficiency
                 // COP (Coefficient of Performance) features - primary source
                 copTotal: find(['heating.cop.total']),

--- a/static/js/dashboard-render-heating.js
+++ b/static/js/dashboard-render-heating.js
@@ -814,6 +814,7 @@
             const operatingProgram = find([`${circuitPrefix}.operating.programs.active`]);
             const circuitTemp = find([`${circuitPrefix}.sensors.temperature.supply`]);
             const roomTemp = find([`${circuitPrefix}.sensors.temperature.room`]);
+            const circuitPump = findNested(`${circuitPrefix}.circulation.pump`, 'status');
             const heatingCurveSlope = findNested(`${circuitPrefix}.heating.curve`, 'slope');
             const heatingCurveShift = findNested(`${circuitPrefix}.heating.curve`, 'shift');
             const supplyTempMax = findNested(`${circuitPrefix}.temperature.levels`, 'max');
@@ -1040,6 +1041,18 @@
                     <div class="status-item">
                         <span class="status-label">Raumtemperatur (Ist)</span>
                         <span class="status-value">${formatValue(roomTemp)}</span>
+                    </div>
+                `;
+            }
+
+            // Circulation pump status (only show if feature has status property)
+            if (circuitPump) {
+                const pumpStatus = circuitPump.value;
+                const statusDisplay = pumpStatus === 'on' ? '🔄 Ein' : (pumpStatus === 'off' ? '⚪ Aus' : pumpStatus);
+                html += `
+                    <div class="status-item">
+                        <span class="status-label">Umwälzpumpe</span>
+                        <span class="status-value">${statusDisplay}</span>
                     </div>
                 `;
             }


### PR DESCRIPTION
## Summary
Fügt die Anzeige der Zirkulationspumpe (Umwälzpumpe) für jeden Heizkreis im Dashboard hinzu. Die Pumpe wird nur angezeigt, wenn die entsprechende Feature im API vorhanden ist.

## Changes
- **dashboard-render-engine.js**: Mapping für `heating.circuits.0-3.circulation.pump` hinzugefügt
- **dashboard-render-heating.js**: Status-Anzeige für Umwälzpumpe in jedem Heizkreis implementiert
  - Icon: 🔄 Ein (bei "on"), ⚪ Aus (bei "off")
  - Nur sichtbar wenn `properties.status` im API vorhanden ist

## Test plan
- [ ] Dashboard öffnen und Heizkreise anzeigen
- [ ] Zirkulationspumpen-Status sollte bei jedem Heizkreis sichtbar sein (falls verfügbar)
- [ ] Status sollte korrekt auf "Ein" oder "Aus" prüfen

Fixes #66