### PR TITLE
Gateway-Events in Event Timeline anzeigen

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2048,7 +2048,7 @@ ${formatEventBody(event.body)}
                                 'gateway-online': { color: '#10b981', label: 'Gateway Online', icon: '🟢' },
                                 'gateway-offline': { color: '#ef4444', label: 'Gateway Offline', icon: '🔴' },
                                 'feature-changed': { color: '#3b82f6', label: 'Feature Changed', icon: '🔧' },
-                                'firmware-update-status': { color: '#8b5cf6', label: '📦 Firmware Update', icon: '📦' }
+                                'firmware-update-status': { color: '#8b5cf6', label: 'Firmware Update', icon: '📦' }
                             };
 
                             const config = pointEventConfig[eventType] || {


### PR DESCRIPTION
## Problem

Gateway-Events wie `gateway-online`, `gateway-offline`, `feature-changed` und `firmware-update-status` waren bisher nicht in der Event Timeline sichtbar, da sie:
- Kein `active` Field haben (keine Start/Ende-Zeitspanne)
- Mit `model_id = 'Unknown'` und `device_id = '0'` gespeichert werden
- Als "Unknown (0)" angezeigt wurden, was nicht aussagekräftig ist

## Lösung

### 1. Point-Events Unterstützung
- Events ohne `active` Field werden als "Point-Events" erkannt
- Werden als 5-Minuten-Marker in der Timeline visualisiert

### 2. Gateway-Benennung
- `Unknown (0)` wird jetzt als **Gateway** angezeigt

### 3. Visualisierung
Point-Events werden mit farbigen Icons dargestellt:
- 🟢 **Gateway Online** - Grün
- 🔴 **Gateway Offline** - Rot
- 🔧 **Feature Changed** - Blau
- 📦 **Firmware Update** - Lila

### 4. Tooltips
- Point-Events zeigen nur den Zeitpunkt (nicht Start/Ende/Dauer)
- Normale Events zeigen weiterhin Start, Ende und Dauer

### 5. Filter
- Alle Gateway-Event-Typen können einzeln gefiltert werden
- Filter werden im LocalStorage gespeichert

## Screenshots

Gateway-Events sind jetzt in der Timeline als farbige Marker sichtbar und können nach Event-Typ gefiltert werden.

Fixes #219