### PR TITLE
fix: 4/3-Wege-Ventil Beschriftung für neuen API-Wert #229

### DIFF
--- a/static/js/dashboard-refrigerant-visual.js
+++ b/static/js/dashboard-refrigerant-visual.js
@@ -26,7 +26,7 @@ function renderRefrigerantCircuitVisual(keyFeatures) {
     let baseImage = compressorActive ?
         '/static/img/vitocal/Kaeltekreislauf%20ein.jpg' : '/static/img/vitocal/Kaeltekreislauf%20aus.jpg';
 	if (compressorActive && keyFeatures?.fourWayValve && 
-		(keyFeatures.fourWayValve.value === 'climatCircuitTwoDefrost' || keyFeatures.fourWayValve.value === 'climateCircuitTwoDefrostDomesticHotWater' || keyFeatures.fourWayValve.value === 'defrost')) {
+		(keyFeatures.fourWayValve.value === 'climatCircuitTwoDefrost' || keyFeatures.fourWayValve.value === 'defrost')) {
         baseImage = '/static/img/vitocal/Kaeltekreislauf%20abtau.jpg';
     }
 


### PR DESCRIPTION
## Summary

- Neuen API-Wert `climateCircuitTwoDefrostDomesticHotWater` mit Beschriftung **Warmwasser** im Ventil-Label-Mapping hinzugefügt (`dashboard-render-heating.js`)
- Warmwasser-Highlight (Feuer-Background auf dem Temperatur-Tile) wird jetzt auch bei dem neuen Ventilwert aktiviert
- Kühlkreislauf-Abtau-Bild (`dashboard-refrigerant-visual.js`) erkennt ebenfalls den neuen kombinierten Wert

## Test plan

- [ ] Warmwasser laden starten und prüfen, dass das 4/3-Wege-Ventil **Warmwasser** anzeigt (nicht mehr den Rohtext aus der API)
- [ ] Prüfen, dass das Warmwasser-Temperatur-Tile während des Ladens das Feuer-Highlight zeigt
- [ ] Bei einem Vitocal prüfen, dass das Kühlkreislauf-Bild während Abtauen + Warmwasser korrekt auf das Abtau-Bild wechselt

Fixes #229