### PR TITLE
show spreizung when compressor is active

### DIFF
--- a/static/js/dashboard-render-heating.js
+++ b/static/js/dashboard-render-heating.js
@@ -210,12 +210,13 @@
                     `;
                 }
             }
-            // Spreizung Sekundärkreis/Heizkreis - use central calculation
 
-            // Only show spreizung when compressor is active
+            // Only show spreizung when compressor is active or volumetric flow
+			const volumetricFlowValue = kf.volumetricFlow ? unwrapValue(kf.volumetricFlow.value) : null;
 			// Use compressorActive boolean if available, otherwise fall back to compressorSpeed
             const isRunning = kf.compressorActive ? kf.compressorActive.value : (kf.compressorSpeed && kf.compressorSpeed.value > 0);
-            if (isRunning) {
+            if ((typeof volumetricFlowValue === 'number' && volumetricFlowValue > 50.0) || isRunning) {
+	            // Spreizung Sekundärkreis/Heizkreis - use central calculation
                 const spreizungResult = calculateSpreizung(kf, hasHotWaterBuffer);
                 if (spreizungResult.spreizung !== null) {
                     tempsGroup2 += `


### PR DESCRIPTION
systems may not have a volumetric sensor, therefore to show deltaT (Spreizung) having the compressor running is sufficent